### PR TITLE
Fixed: removed default Hover underline and color of contact us, correct contact phone icon  #66 

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -88,7 +88,7 @@ function Footer() {
                   <span>contact@placementsystem.com</span>
                 </li>
                 <li>
-                  <FaPhone className="contact-icon" />
+                  <FaPhone className="contact-icon phone" />
                   <span>(555) 123-4567</span>
                 </li>
               </ul>
@@ -106,7 +106,7 @@ function Footer() {
             <a href="/signin" className="footer-cta-button">
               Sign In
             </a>
-            <a href="/contact" className="footer-cta-button outline">
+            <a href="/contact" className="outline">
               Contact Us
             </a>
           </div>

--- a/frontend/src/components/footer.css
+++ b/frontend/src/components/footer.css
@@ -188,6 +188,9 @@
   gap: 1rem;
 }
 
+.phone {
+  transform: rotateZ(90deg);
+}
 .footer-cta-button {
   padding: 0.6rem 1.25rem;
   border-radius: 0.375rem;
@@ -203,23 +206,36 @@
   color: white;
   border: 1px solid var(--primary-color);
 }
-
-.footer-cta-button.outline {
-  background: transparent;
-  color: var(--primary-color);
+.outline {
+  padding: 0.6rem 1.25rem;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  transition: all var(--transition-speed) ease;
+  color: white;
+  outline-color: var(--primary-color);
   border: 1px solid var(--primary-color);
 }
 
-.footer-cta-button:hover {
+
+.footer-cta .outline {
+  background: transparent;
+  color: white;
+  outline-color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+}
+
+.outline:hover, .footer-cta-button:hover {
   background: var(--primary-hover);
   border-color: var(--primary-hover);
   transform: translateY(-2px);
   color: white;
+  text-decoration: none;
 }
 
-.footer-cta-button.outline:hover {
+.footer-cta-button .outline:hover {
   background: rgba(128, 0, 0, 0.1);
-  color: var(--primary-hover);
+  background-color: var(--primary-hover);
 }
 
 /* Light Mode Styles */


### PR DESCRIPTION
Solved issue #66 
This PR is opened under Gssoc'25
@213sanjana  please review the PR and merge it
CORRECTIONS-
  Corrected the phone icon
  Changed the color of contact us which was same as border
  Removed underline when hovered
https://github.com/user-attachments/assets/9c7b0266-85a4-45fc-95d0-d2550c99457c

