### PR TITLE
Fix: Page Scroll Position on Navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,90 +14,119 @@ import AdminManagement from "./components/AdminManagement";
 import ProtectedRoute from "./components/ProtectedRoute";
 import JobsPage from "./components/jobs";
 import InterviewExperience from "./components/InterviewExperience";
+import ScrollToTop from "./components/ScrollToTop";
 
 
 function App() {
   return (
     <Router>
+      <ScrollToTop /> {/* Always keep this inside Router */}
       <div className="app-container">
         <Routes>
-          <Route path="/interview-experience" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <InterviewExperience />
-              </main>
-              <Footer />
-            </>
-          } />
+          <Route
+            path="/interview-experience"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <InterviewExperience />
+                </main>
+                <Footer />
+              </>
+            }
+          />
           {/* Public routes */}
-          <Route path="/" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <Home />
-              </main>
-              <Footer />
-            </>
-          } />
-          <Route path="/signin" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <Sign />
-              </main>
-              <Footer />
-            </>
-          } />
-          <Route path="/about" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <About />
-              </main>
-              <Footer />
-            </>
-          } />
-          <Route path="/contact" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <Contact />
-              </main>
-              <Footer />
-            </>
-          } />
-          <Route path="/profile" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <StudentProfile />
-              </main>
-              <Footer />
-            </>
-          } />
-          <Route path="/jobs" element={
-            <>
-              <Header />
-              <main className="main-content">
-                <JobsPage />
-              </main>
-              <Footer />
-            </>
-          } />
-          
+          <Route
+            path="/"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <Home />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+          <Route
+            path="/signin"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <Sign />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+          <Route
+            path="/about"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <About />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+          <Route
+            path="/contact"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <Contact />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <StudentProfile />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+          <Route
+            path="/jobs"
+            element={
+              <>
+                <Header />
+                <main className="main-content">
+                  <JobsPage />
+                </main>
+                <Footer />
+              </>
+            }
+          />
+
           {/* Admin routes */}
           <Route path="/admin-login" element={<AdminLogin />} />
-          <Route path="/admin-job-posting" element={
-            <ProtectedRoute requireAdmin={true}>
-              <AdminJobPosting />
-            </ProtectedRoute>
-          } />
-          <Route path="/admin-management" element={
-            <ProtectedRoute requireAdmin={true}>
-              <AdminManagement />
-            </ProtectedRoute>
-          } />
+          <Route
+            path="/admin-job-posting"
+            element={
+              <ProtectedRoute requireAdmin={true}>
+                <AdminJobPosting />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin-management"
+            element={
+              <ProtectedRoute requireAdmin={true}>
+                <AdminManagement />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </div>
     </Router>

--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]); 
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
#91 Description:
This PR fixes the problem where certain pages were loading from the middle or bottom instead of starting at the top when navigating between routes.

Changes Made:
Implemented a ScrollToTop component using useEffect with window.scrollTo(0, 0).
Applied the component across all routes/pages to ensure consistency.
Tested and confirmed that pages now reset scroll position to the top on navigation.

How to Test:
Navigate between different routes/pages.
Confirm that each new page opens from the top, regardless of the scroll position on the previous page.
Test on multiple devices and browsers for consistent behavior.

Before:
Pages sometimes loaded in the middle/bottom position.

After:
Pages now always load from the top, ensuring a smoother user experience.