### PR TITLE
Added navigation links to "Register Now" and "Contact Us" buttons on homepage CTA section

### DIFF
--- a/frontend/src/components/home.jsx
+++ b/frontend/src/components/home.jsx
@@ -256,12 +256,12 @@ function Home() {
             Join thousands of successful alumni who started their journey at CGC Jhanjeri
           </p>
           <div className="cta-buttons">
-            <button className="btn btn-primary">
+            <a href="/signin" className="btn btn-primary">
               Register Now
-            </button>
-            <button className="btn btn-outline">
+            </a>
+            <a href="/Contact" className="btn btn-outline">
               Contact Us
-            </button>
+            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Description
This PR addresses the issue where the "Register Now" and "Contact Us" buttons in the homepage CTA section were non-responsive and did not navigate to their intended pages.

## Changes Implemented

1. Updated the CTA buttons to include navigation links.
2. Linked "Register Now" button to the /register page.
3. Linked "Contact Us" button to the /contact page.
4. Ensured buttons are fully responsive across devices.

## Related Issue
Closes #105 

## Steps to Test

- Navigate to the homepage.
- Click on "Register Now" → should redirect to /signin.
- Click on "Contact Us" → should redirect to /Contact.
- Verify responsiveness across desktop and mobile view.

## Expected Behavior

- Both buttons redirect to their respective pages correctly.
- Navigation works seamlessly across all devices.

## Screenshots:
<img width="1907" height="871" alt="image" src="https://github.com/user-attachments/assets/871b6ac8-6a81-4536-b64b-a61e7f5d4840" />

<img width="1908" height="883" alt="image" src="https://github.com/user-attachments/assets/ef5fc11f-5ed6-490d-983f-1e5a8cc6398b" />

<img width="1912" height="896" alt="image" src="https://github.com/user-attachments/assets/b7409c2f-de49-4655-97ad-7d2268130ab1" />

## Additional Context:
Kindly review and merge the PR. @213sanjana @Poushmita 