### PR TITLE
Contact Style Updated in Light Mode

### DIFF
--- a/frontend/src/components/contact.css
+++ b/frontend/src/components/contact.css
@@ -1110,3 +1110,69 @@ body.light .success-animation p {
 .team-card {
   animation-delay: calc(var(--index) * 0.1s);
 }}
+
+/* new styling for light mode */
+body.light .contact-hero h1{
+  color: #8f0101;
+}
+
+body.light .contact-hero p{
+  color:#ffffff;
+}
+
+body.light .contact-card,
+body.light .executive-card,
+body.light .team-card {
+  background: #d6c9c9;   
+  color: #1a1a1a;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+body.light .contact-card h2,
+body.light .executive-card h2,
+body.light .team-card h3 {
+  color: #800000;
+}
+
+body.light .contact-card .contact-label,
+body.light .executive-card .contact-label,
+body.light .team-card .contact-label {
+  font-weight: bold;
+  color: #800000;
+}
+
+body.light .contact-card a,
+body.light .executive-card a,
+body.light .team-card a {
+  color: #0f0808; 
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+body.light .contact-card p {
+  color:#0f0808;
+}
+
+body.light .contact-card a:hover,
+body.light .executive-card a:hover,
+body.light .team-card a:hover {
+  color: #000000;
+  text-decoration: underline;
+}
+
+body.light .team-card:hover{
+  background-color: #a39292;
+}
+
+body.light .team-card h3{
+  color:#5f0101;
+}
+
+body.light .team-card p.team-title{
+  color: #960328;
+}
+
+body.light .team-card p.team-title:hover{
+  color: #520216;
+}


### PR DESCRIPTION
Hello, Tushar Sonawane, GSSOC'25, here, 

Closes #123 

Changes Made:-
This PR introduces UI improvements to the Light/Dark Mode toggle and fixes link visibility issues:
1. Light Theme Enhancements
2. Added a soft off-white background for better contrast instead of plain white.
3. Updated text colors inside cards (contact-card, executive-card, team-card) to ensure clear visibility on light backgrounds.
4. Link Hover Fix
5. Fixed issue where Phone and Email links blended into the background on hover.
6. Now, links are maroon by default and turn black (#000000) on hover for readability.
7. Added smooth transition and optional underline effect for clarity.
8. Consistency Across Cards
9. Ensured that all cards (contact, executive, team) properly inherit the new theme styles.

 Impact:-
1. Improves overall user experience in light mode.
2. Fixes readability issues with hover states.
3. Ensures consistent styling across all cards.

📸 ScreenShots (After Changes):-
<img width="1364" height="687" alt="ss 1" src="https://github.com/user-attachments/assets/bdc64512-e048-400c-bb13-a36b24a4d035" />
<img width="1361" height="683" alt="ss 2" src="https://github.com/user-attachments/assets/10c85239-a3c0-41f4-bae0-6c669be0d925" />
<img width="1366" height="682" alt="ss 3" src="https://github.com/user-attachments/assets/ab76d386-5f58-41d0-a93d-629a183965d4" />


 Note:-
1. Tested in both light and dark modes.
2. No breaking changes introduced.
3. Only CSS updates applied.
