### PR TITLE
fix(home): make 'Learn More' button navigate to About page (#161)

### DIFF
--- a/frontend/src/components/home.jsx
+++ b/frontend/src/components/home.jsx
@@ -3,7 +3,7 @@
 import cgcBack from "../assets/cgc back2.png";
 import "./home.css";
 import { Star, Users, TrendingUp, Calendar, FileText, Award, Target, Shield, Zap, Globe, BookOpen, Briefcase } from 'lucide-react';
-
+import { Link } from "react-router-dom";
 function Home() {
   const features = [
     {
@@ -114,9 +114,9 @@ function Home() {
             <button className="btn btn-primary">
               Explore Opportunities
             </button>
-            <button className="btn btn-secondary">
+            <Link to="/About" className="btn btn-secondary">
               Learn More
-            </button>
+            </Link>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #161 

## Rationale for this change

The "Learn More" button on the homepage was non-functional and did not redirect anywhere.  
This broke navigation and prevented users from accessing important information about the portal/university.  

## What changes are included in this PR?

- Updated the "Learn More" button in `Home.jsx` to navigate to the `/About` page using React Router.  
- Ensured consistent navigation behavior with other buttons/links.  

## Are these changes tested?

- Yes, tested locally by running the frontend and verifying that clicking **Learn More** redirects correctly to `/About`.  

## Are there any user-facing changes?

- Yes. The "Learn More" button on the homepage now properly redirects to the About page.  


before : 

https://github.com/user-attachments/assets/0fcf31ff-db98-4ea5-933f-26ae01b81110

after :

https://github.com/user-attachments/assets/bebadb9b-07cd-4861-9dab-f0afd731b3b4

