### PR TITLE
[Fix]: Password validation on Sign in page

### DIFF
--- a/frontend/src/components/Sign.jsx
+++ b/frontend/src/components/Sign.jsx
@@ -48,7 +48,7 @@ function Sign() {
     } else if (name === "email") {
       // specific format validation
       if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) error = "Enter a valid email address";
-    } else if (name === "password") {
+    } else if (name === "password" && isRegister) {
       if (value.length < 8) error = "Password must be at least 8 characters";
     } else if (name === "confirmPassword") {
       if (value !== form.password) error = "Passwords do not match";
@@ -214,7 +214,7 @@ function Sign() {
               </span>
             </div>
 
-            {isRegister && ((touched.password || errors.password) && errors.password) && (
+            {((touched.password || errors.password) && errors.password) && (
               <div id="password-error" className="error-text" role="alert">
                 <span className="error-icon" aria-hidden="true">⚠</span>
                 <span>{errors.password}</span>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #190.

## PR summary

In this PR: on the sign-in page, we don’t need to enforce password validation. We just need to check whether the password is correct or not.

## ScreenShots

Before 
<img width="454" height="467" alt="Screenshot 2025-09-23 165124" src="https://github.com/user-attachments/assets/60dd0ca9-5274-4a8f-9ad4-d12d55f4ce09" />

After
<img width="397" height="419" alt="Screenshot 2025-09-23 165327" src="https://github.com/user-attachments/assets/65ff08a8-a759-434b-b562-e6565b081b0a" />
