### PR TITLE
Link fixed

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { toast } from "react-hot-toast";
 import {
@@ -129,7 +130,7 @@ function Footer() {
               <h4 className="footer-heading">Navigation</h4>
               <ul className="footer-nav">
                 <li><a href="/">Home</a></li>
-                <li><a href="/about">About Us</a></li>
+                <li><Link to="/about">About Us</Link></li>
                 <li><a href="/jobs">Job Listings</a></li>
                 <li><a href="/profile">My Profile</a></li>
                 <li><a href="/admin-job-posting">Post Jobs</a></li>


### PR DESCRIPTION
Hello, Tushar Sonawane, GSSOC'25 Contributor, here,

## Which issue does this PR close?

- Closes #185  .

## Rationale for this change

The option of "About us" from the footer was not working as it was giving an error page when open. So, now the it is being updated, now the page should get load and get opened. 

## What changes are included in this PR?

The "About us" option from the footer has being made working. 

## Are these changes tested?

Yes, the changes are tested on the localhost on my local machine.

## Are there any user-facing changes?

Yes, now the user can visit the about page from the footer too.

Image of the about working:-
<img width="1361" height="721" alt="get 5" src="https://github.com/user-attachments/assets/803fc12c-960d-4930-821d-d00ca5ea95d9" />

