### PR TITLE
Form Styling Fixed

### DIFF
--- a/frontend/src/components/contact.css
+++ b/frontend/src/components/contact.css
@@ -1251,3 +1251,37 @@ body.light .progress-step{
 body.light .form-toggle-icon{
   color:#000000;
 }
+
+body.dark #name{
+  background-color: #14141499;
+  color:white;
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.2);
+}
+body.dark #email{
+  background-color: #14141499;
+  color:white;
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.2);
+}
+body.dark #subject{
+  background-color: #14141499;
+  color:white;
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.2);
+}
+body.dark #phone{
+  background-color: #14141499;
+  color:white;
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.2);
+}
+body.dark #message{
+  color:white;
+  border-color: #e53e3e;
+  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.2);
+}
+body.dark .form-group.floating .error-message{
+  background: #14141499;
+  color:white;
+}


### PR DESCRIPTION
Hello, Tushar Sonawane, GSSOC'25 Contributor, here, 

## Which issue does this PR close?

- Closes #201 .

## Rationale for this change

Earlier the On contact page , in Dark mode, form input options were having the wrong background color as well the text color and also with that the box shadow, border styling was missing due to which the form was not putting a impression on the users. 
## What changes are included in this PR?

1. Changed the background color and text color of the form input. 
2. Added the border styling to each input option.
3. Added the box shadow to the each input option.

## Are these changes tested?

Yes, these all changes are tested on the localhost and everything is working fine.

## Are there any user-facing changes?

Yes, now in dark mode, the user can have the perfect form with consistent styling.

## Image of the updated form:-
<img width="1366" height="672" alt="mota 1" src="https://github.com/user-attachments/assets/6329be94-6a83-448e-996b-eb35eeecaf0e" />

