### PR TITLE
Added space between team-section and footer

### DIFF
--- a/frontend/src/components/contact.css
+++ b/frontend/src/components/contact.css
@@ -357,7 +357,7 @@ body.light .executive-contact p {
 .team-section {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 2rem 2rem 2rem;
 }
 
 .team-section h2 {


### PR DESCRIPTION
This PR closes #292 

updated:
<img width="1905" height="662" alt="image" src="https://github.com/user-attachments/assets/75218b8c-5ea7-4f39-aca2-8a822a459e3f" />
