### PR TITLE
Improved Hover Animation for About Page Cards

### DIFF
--- a/frontend/src/components/About.jsx
+++ b/frontend/src/components/About.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Sun, Moon, Users, Target, Award, Building, Calendar, BarChart3, ChevronDown, Sparkles, Rocket, TargetIcon, Zap } from "lucide-react";
 import collegeLogo from "../assets/cgc logo.png";
+import "./about.css";
 
 function About() {
   const [isDark, setIsDark] = useState(false);

--- a/frontend/src/components/about.css
+++ b/frontend/src/components/about.css
@@ -556,3 +556,25 @@ body.dark .about-button span {
 .about-bg::-webkit-scrollbar-thumb:hover {
   background: linear-gradient(135deg, #2563EB, #7C3AED);
 }
+
+.about-feature {
+  transform: translateY(0) scale(1);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  will-change: transform, box-shadow;
+}
+
+.about-feature:hover {
+  transform: translateY(-4px) scale(1.04) !important;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.group {
+  transform: translateY(0) scale(1);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  will-change: transform, box-shadow;
+}
+
+.group:hover {
+  transform: translateY(-8px) scale(1.04) !important;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #310 .

## Rationale for this change

On the privacy page, there are the cards on the features section and the placed section there was not any transition when it was hovered. But, now the transition has been added, which are enhancing the ui.

## What changes are included in this PR?
1. Added smooth uplift + scale transition to .about-feature and .about-placed cards.
2. Applied a soft box-shadow on hover for better visual depth.
3. Improved hover transition timing for smoother animations.
4. Ensured consistent hover behavior between feature and stats cards

## Are these changes tested?

Yes, all the changes are tested on the localhost.

## Are there any user-facing changes?

Yes, now when the users will hovers over the specific sections on the privacy policy page they can see the transition after they hover it.
